### PR TITLE
Fixed PHP Strict standards

### DIFF
--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
@@ -7,6 +7,7 @@ use AntiMattr\MongoDB\Migrations\Migration;
 use AntiMattr\MongoDB\Migrations\Tools\Console\Command\StatusCommand;
 use AntiMattr\TestCase\AntiMattrTestCase;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -223,7 +224,7 @@ class StatusCommandStub extends StatusCommand
         $this->configuration = $configuration;
     }
 
-    public function getMigrationConfiguration()
+    public function getMigrationConfiguration(InputInterface $input, OutputInterface $output)
     {
         return $this->configuration;
     }


### PR DESCRIPTION
Fixes the following:

- PHP Strict standards:  Declaration of AntiMattr\Tests\MongoDB\Migrations\Tools\Console\Command\StatusCommandStub::getMigrationConfiguration() should be compatible with AntiMattr\MongoDB\Migrations\Tools\Console\Command\AbstractCommand::getMigrationConfiguration(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) in /home/travis/build/caciobanu/mongodb-migrations/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php on line 218