### PR TITLE
Feature/status descriptions

### DIFF
--- a/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
@@ -296,6 +296,38 @@ class Configuration
     }
 
     /**
+     * Returns the time a migration occurred.
+     *
+     * @param string $version
+     *
+     * @return string
+     *
+     * @throws AntiMattr\MongoDB\Migrations\Exception\UnknownVersionException Throws exception if migration version does not exist
+     */
+    public function getMigratedTimestamp($version)
+    {
+        $this->createMigrationCollection();
+
+        $cursor = $this->getCollection()->find(
+            ['v' => $version]
+        );
+
+        if (!$cursor->count()) {
+            throw new UnknownVersionException($version);
+        }
+
+        if ($cursor->count() > 1) {
+            throw \DomainException(
+                'Unexpected duplicate version records in the database'
+            );
+        }
+
+        $returnVersion = $cursor->getNext();
+
+        return (string) $returnVersion['t'];
+    }
+
+    /**
      * Return all migrated versions from versions collection that have migration files deleted.
      *
      * @return array

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
@@ -309,7 +309,7 @@ class Configuration
         $this->createMigrationCollection();
 
         $cursor = $this->getCollection()->find(
-            ['v' => $version]
+            array('v' => $version)
         );
 
         if (!$cursor->count()) {

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -29,10 +29,17 @@ abstract class AbstractCommand extends Command
      */
     private $configuration;
 
+    /**
+     * configure.
+     */
     protected function configure()
     {
-        $this->addOption('configuration', null, InputOption::VALUE_OPTIONAL, 'The path to a migrations configuration file.');
-        $this->addOption('db-configuration', null, InputOption::VALUE_OPTIONAL, 'The path to a database connection configuration file.');
+        $this->addOption(
+            'configuration', null, InputOption::VALUE_OPTIONAL, 'The path to a migrations configuration file.'
+        );
+        $this->addOption(
+            'db-configuration', null, InputOption::VALUE_OPTIONAL, 'The path to a database connection configuration file.'
+        );
     }
 
     /**

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
@@ -149,7 +149,13 @@ EOT
             if ($executedUnavailableMigrations) {
                 $output->writeln("\n <info>==</info> Previously Executed Unavailable Migration Versions\n");
                 foreach ($executedUnavailableMigrations as $executedUnavailableMigration) {
-                    $output->writeln('    <comment>>></comment> '.Configuration::formatVersion($executedUnavailableMigration).' (<comment>'.$executedUnavailableMigration.'</comment>)');
+                    $output->writeln(
+                        sprintf(
+                            '    <comment>>></comment> %s (<comment>%s</comment>)',
+                            Configuration::formatVersion($executedUnavailableMigration),
+                            $executedUnavailableMigration
+                        )
+                    );
                 }
             }
         }

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
@@ -131,10 +131,6 @@ EOT
                     }
 
                     $versionTxt = sprintf('<comment>%s</comment>', $version->getVersion());
-                    if (!$version->getMigration()) {
-                        $e = new \Exception();
-                        print_r(str_replace('/path/to/code/', '', $e->getTraceAsString()));
-                    }
                     $desc = $version->getMigration()->getDescription();
                     if (strlen($desc) > 80) {
                         $desc = substr($desc, 0, 78).'...';

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
@@ -112,7 +112,7 @@ EOT
         if ($input->getOption('show-versions')) {
             if ($migrations = $configuration->getMigrations()) {
                 $output->writeln("\n <info>==</info> Available Migration Versions\n");
-                $rows = [];
+                $rows = array();
                 $migratedVersions = $configuration->getMigratedVersions();
 
                 foreach ($migrations as $version) {
@@ -136,7 +136,7 @@ EOT
                         $desc = substr($desc, 0, 78).'...';
                     }
 
-                    $rows[] = [$versionTxt, $status, $desc];
+                    $rows[] = array($versionTxt, $status, $desc);
                 }
 
                 $table = new Table($output);

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
@@ -144,6 +144,14 @@ EOT
                       ->setRows($rows)
                       ->render();
             }
+
+            $executedUnavailableMigrations = $configuration->getUnavailableMigratedVersions();
+            if ($executedUnavailableMigrations) {
+                $output->writeln("\n <info>==</info> Previously Executed Unavailable Migration Versions\n");
+                foreach ($executedUnavailableMigrations as $executedUnavailableMigration) {
+                    $output->writeln('    <comment>>></comment> '.Configuration::formatVersion($executedUnavailableMigration).' (<comment>'.$executedUnavailableMigration.'</comment>)');
+                }
+            }
         }
     }
 

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
@@ -140,7 +140,7 @@ EOT
                 }
 
                 $table = new Table($output);
-                $table->setHeaders(['Version', 'Date Migrated', 'Description'])
+                $table->setHeaders(array('Version', 'Date Migrated', 'Description'))
                       ->setRows($rows)
                       ->render();
             }

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
@@ -26,10 +26,24 @@ class StatusCommandTest extends AntiMattrTestCase
     {
         $this->command = new StatusCommandStub();
         $this->output = $this->buildMock('Symfony\Component\Console\Output\OutputInterface');
+        $this->outputFormatter = $this->buildMock(
+            'Symfony\Component\Console\Formatter\OutputFormatterInterface'
+        );
+        $this->output
+            ->method('getFormatter')
+            ->will($this->returnValue($this->outputFormatter));
+
         $this->config = $this->buildMock('AntiMattr\MongoDB\Migrations\Configuration\Configuration');
-        $this->migration = $this->buildMock('AntiMattr\MongoDB\Migrations\Migration');
+        $this->migration = $this->buildMock('AntiMattr\MongoDB\Migrations\AbstractMigration');
         $this->version = $this->buildMock('AntiMattr\MongoDB\Migrations\Version');
+        $this->version->expects($this->any())
+            ->method('getMigration')
+            ->will($this->returnValue($this->migration));
+
         $this->version2 = $this->buildMock('AntiMattr\MongoDB\Migrations\Version');
+        $this->version2->expects($this->any())
+            ->method('getMigration')
+            ->will($this->returnValue($this->migration));
 
         $this->command->setMigrationConfiguration($this->config);
     }
@@ -239,16 +253,21 @@ class StatusCommandTest extends AntiMattrTestCase
         $numNewMigrations = 1;
         $notMigratedVersion = '20140822185743';
         $migratedVersion = '20140822185745';
+        $migrationDescription = 'drop all collections';
         $unavailableMigratedVersion = '20140822185744';
 
         // Expectations
-        $this->version->expects($this->exactly(3))
+        $this->version->expects($this->exactly(2))
             ->method('getVersion')
             ->will($this->returnValue($notMigratedVersion));
 
         $this->version2->expects($this->exactly(3))
             ->method('getVersion')
             ->will($this->returnValue($migratedVersion));
+
+        $this->migration
+            ->method('getDescription')
+            ->will($this->returnValue('drop all'));
 
         $this->config->expects($this->once())
             ->method('getDetailsMap')
@@ -287,15 +306,6 @@ class StatusCommandTest extends AntiMattrTestCase
                 )
             )
         ;
-        $this->config->expects($this->once())
-            ->method('getUnavailableMigratedVersions')
-            ->will(
-                $this->returnValue(
-                    array($unavailableMigratedVersion)
-                )
-            )
-        ;
-
         $this->output->expects($this->at(0))
             ->method('writeln')
             ->with(
@@ -421,40 +431,6 @@ class StatusCommandTest extends AntiMattrTestCase
         $this->output->expects($this->at(14))
             ->method('writeln')
             ->with("\n <info>==</info> Available Migration Versions\n")
-        ;
-        $this->output->expects($this->at(15))
-            ->method('writeln')
-            ->with(
-                sprintf(
-                    '    <comment>>></comment> %s (<comment>%s</comment>)                <error>not migrated</error>',
-                    \DateTime::createFromFormat('YmdHis', $notMigratedVersion)->format('Y-m-d H:i:s'),
-                    $notMigratedVersion
-                )
-            )
-        ;
-        $this->output->expects($this->at(16))
-            ->method('writeln')
-            ->with(
-                sprintf(
-                    '    <comment>>></comment> %s (<comment>%s</comment>)                <info>migrated</info>',
-                    \DateTime::createFromFormat('YmdHis', $migratedVersion)->format('Y-m-d H:i:s'),
-                    $migratedVersion
-                )
-            )
-        ;
-        $this->output->expects($this->at(17))
-            ->method('writeln')
-            ->with("\n <info>==</info> Previously Executed Unavailable Migration Versions\n")
-        ;
-        $this->output->expects($this->at(18))
-            ->method('writeln')
-            ->with(
-                sprintf(
-                    '    <comment>>></comment> %s (<comment>%s</comment>)',
-                    \DateTime::createFromFormat('YmdHis', $unavailableMigratedVersion)->format('Y-m-d H:i:s'),
-                    $unavailableMigratedVersion
-                )
-            )
         ;
 
         // Run command, run.

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
@@ -291,6 +291,14 @@ class StatusCommandTest extends AntiMattrTestCase
             )
         ;
         $this->config->expects($this->once())
+            ->method('getUnavailableMigratedVersions')
+            ->will(
+                $this->returnValue(
+                    array($unavailableMigratedVersion)
+                )
+            )
+        ;
+        $this->config->expects($this->once())
             ->method('getMigrations')
             ->will(
                 $this->returnValue(
@@ -431,6 +439,21 @@ class StatusCommandTest extends AntiMattrTestCase
         $this->output->expects($this->at(14))
             ->method('writeln')
             ->with("\n <info>==</info> Available Migration Versions\n")
+        ;
+
+        $this->output->expects($this->at(39))
+            ->method('writeln')
+            ->with("\n <info>==</info> Previously Executed Unavailable Migration Versions\n")
+        ;
+        $this->output->expects($this->at(40))
+            ->method('writeln')
+            ->with(
+                sprintf(
+                    '    <comment>>></comment> %s (<comment>%s</comment>)',
+                    \DateTime::createFromFormat('YmdHis', $unavailableMigratedVersion)->format('Y-m-d H:i:s'),
+                    $unavailableMigratedVersion
+                )
+            )
         ;
 
         // Run command, run.

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
@@ -29,10 +29,6 @@ class StatusCommandTest extends AntiMattrTestCase
         $this->outputFormatter = $this->buildMock(
             'Symfony\Component\Console\Formatter\OutputFormatterInterface'
         );
-        $this->output
-            ->method('getFormatter')
-            ->will($this->returnValue($this->outputFormatter));
-
         $this->config = $this->buildMock('AntiMattr\MongoDB\Migrations\Configuration\Configuration');
         $this->migration = $this->buildMock('AntiMattr\MongoDB\Migrations\AbstractMigration');
         $this->version = $this->buildMock('AntiMattr\MongoDB\Migrations\Version');
@@ -257,6 +253,10 @@ class StatusCommandTest extends AntiMattrTestCase
         $unavailableMigratedVersion = '20140822185744';
 
         // Expectations
+        $this->output
+            ->method('getFormatter')
+            ->will($this->returnValue($this->outputFormatter));
+
         $this->version->expects($this->exactly(2))
             ->method('getVersion')
             ->will($this->returnValue($notMigratedVersion));


### PR DESCRIPTION
This is for #4 plus adds the date the migration was run. Uses the Table formatter.

```bash
== Available Migration Versions

+----------------+------------------+-------------------------------------------------+
| Version        | Date Migrated    | Description                                     |
+----------------+------------------+-------------------------------------------------+
| 20141004024350 | 2014-10-15 22:19 | Add createdAt to users collection               |
| 20141008124412 | 2014-10-08 14:01 | Cast string order key to int                    |
| 20160908231757 | not migrated     | Update user embedded Address _doctrine class    |
+----------------+------------------+-------------------------------------------------+
```