### PR TITLE
Fix/5.3build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
 
 matrix:
   include:
+    - php: 5.3
+      dist: precise
     - php: 7.0
       env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
 


### PR DESCRIPTION
PR https://github.com/doesntmattr/mongodb-migrations/pull/13 was bringing up an unrelated travis build error in php5.3

This PR is to remove that noise. 

The fix was to follow Travis documentation:
https://docs.travis-ci.com/user/reference/trusty#PHP-images