### PR TITLE
Fix/7.0build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   include:
     - php: 5.3
       dist: precise
-    - php: 7.0
+    - php: 7.1
       env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
 
 services: mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
 
 matrix:
   include:
+    - php: 5.3
+      dist: precise
     - php: 7.0
       env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
 


### PR DESCRIPTION
This follows from (branched from) https://github.com/doesntmattr/mongodb-migrations/pull/14

Jump php7.0 and go to 7.1 because doctrine/annotations demanded it.