### PR TITLE
V2/remove antimattr test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 
 before_script:
   # Not using code coverage
-  - phpenv config-rm xdebug.ini
+  - if [[ ${TRAVIS_PHP_VERSION} != "nightly" ]]; then phpenv config-rm xdebug.ini; fi
   - pecl install -f mongodb-stable
   - composer config "platform.ext-mongo" "1.6.16"
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,28 +8,20 @@ cache:
 matrix:
   include:
     # Test the latest
-    - php: 5.6
-      env: MONGO_VERSION=stable
     - php: 7.1
-      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
     - php: 7.2
-      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
+    - php: nightly
 
     # Test with the lowest deps
-    - php: 5.6
-      env: MONGO_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest --prefer-dist"
     - php: 7.2
-    # Note that the ADAPTER_VERSION is pinned to 1.0.0 when testing lowest deps
-      env: ADAPTER_VERSION="1.0.0" MONGODB_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest --prefer-dist"
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest --prefer-dist"
 
 before_script:
   # Not using code coverage
   - phpenv config-rm xdebug.ini
-  - if ! [ -z "$MONGO_VERSION" ]; then yes '' | pecl -q install -f mongo-${MONGO_VERSION}; fi
-  - if ! [ -z "$MONGODB_VERSION" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi
-  - if ! [ -z "$ADAPTER_VERSION" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
+  - pecl install -f mongodb-stable
   - composer self-update
-  # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
+  # To be removed when this issue is resolved: https://github.com/composer/composer/issues/5355
   - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --ignore-platform-reqs --quiet; fi
   - composer update -v ${COMPOSER_FLAGS}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_script:
   # Not using code coverage
   - phpenv config-rm xdebug.ini
   - pecl install -f mongodb-stable
+  - composer config "platform.ext-mongo" "1.6.16"
   - composer self-update
   # To be removed when this issue is resolved: https://github.com/composer/composer/issues/5355
   - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --ignore-platform-reqs --quiet; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
     # Test the latest
     - php: 7.1
     - php: 7.2
-    - php: nightly
 
     # Test with the lowest deps
     - php: 7.2
@@ -18,7 +17,7 @@ matrix:
 
 before_script:
   # Not using code coverage
-  - if [[ ${TRAVIS_PHP_VERSION} != "nightly" ]]; then phpenv config-rm xdebug.ini; fi
+  - phpenv config-rm xdebug.ini
   - pecl install -f mongodb-stable
   - composer config "platform.ext-mongo" "1.6.16"
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "alcaeus/mongo-php-adapter": "^1.0"
     },
     "require-dev": {
-        "antimattr/test-case": "~1.0@stable",
         "phpunit/phpunit": "^5.0",
         "phpunit/phpunit-mock-objects": ">=3.0.4",
         "sebastian/version": ">=1.0.3",

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,11 @@
         "antimattr/mongodb-migrations" : "*"
     },
     "require": {
-        "php": "^5.6|^7.1",
+        "php": "^7.1",
         "doctrine/mongodb": "^1.0",
         "symfony/console": "^2.7|^3.3|^4",
-        "symfony/yaml": "^2.7|^3.3|^4"
+        "symfony/yaml": "^2.7|^3.3|^4",
+        "alcaeus/mongo-php-adapter": "^1.0"
     },
     "require-dev": {
         "antimattr/test-case": "~1.0@stable",
@@ -42,7 +43,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     },
     "archive": {

--- a/tests/AntiMattr/TestCase/AntiMattrTestCase.php
+++ b/tests/AntiMattr/TestCase/AntiMattrTestCase.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the AntiMattr TestCase Library, a library by Matthew Fitzgerald.
+ *
+ * (c) 2014 Matthew Fitzgerald
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AntiMattr\TestCase;
+
+use DateTime;
+use PHPUnit_Framework_TestCase;
+
+abstract class AntiMattrTestCase extends PHPUnit_Framework_TestCase
+{
+    protected function buildMock($class)
+    {
+        return $this->getMockBuilder($class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /*
+     * Returns DateTime with timezone set. If timezone is not set, you'll get the following error:
+     * Exception: DateTime::__construct(): It is not safe to rely on the system's timezone settings.
+     * You are *required* to use the date.timezone setting or the date_default_timezone_set() function.
+     */
+    protected function createDateTime($time = null)
+    {
+        $time = $time ? : 'now';
+
+        return new DateTime($time);
+    }
+}


### PR DESCRIPTION
We can remove the AntiMattrTestCase class all together at some point.

For now, just migrating over to be able to control the library.

Towards v2.0 #22 