### PR TITLE
V2/drop php adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
   # Remove xdebug at the start
   - phpenv config-rm xdebug.ini
   - pecl install -f mongodb-stable
+  # Until doctrine/mongo switches to mongodb driver
   - composer config "platform.ext-mongo" "1.6.16"
   - composer self-update
   # To be removed when this issue is resolved: https://github.com/composer/composer/issues/5355

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         "php": "^7.1",
         "doctrine/mongodb": "^1.0",
         "symfony/console": "^2.7|^3.3|^4",
-        "symfony/yaml": "^2.7|^3.3|^4",
-        "alcaeus/mongo-php-adapter": "^1.0"
+        "symfony/yaml": "^2.7|^3.3|^4"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
@@ -17,6 +17,7 @@ use AntiMattr\MongoDB\Migrations\Exception\UnknownVersionException;
 use AntiMattr\MongoDB\Migrations\OutputWriter;
 use AntiMattr\MongoDB\Migrations\Version;
 use Doctrine\MongoDB\Connection;
+use Doctrine\MongoDB\Database;
 
 /**
  * @author Matthew Fitzgerald <matthewfitz@gmail.com>
@@ -172,9 +173,9 @@ class Configuration
     }
 
     /**
-     * @return Doctrine\MongoDB\Connection
+     * @return Doctrine\MongoDB\Database
      */
-    public function getDatabase()
+    public function getDatabase(): ?Database
     {
         if (isset($this->database)) {
             return $this->database;

--- a/src/AntiMattr/MongoDB/Migrations/Version.php
+++ b/src/AntiMattr/MongoDB/Migrations/Version.php
@@ -18,7 +18,7 @@ use AntiMattr\MongoDB\Migrations\Exception\AbortException;
 use Doctrine\MongoDB\Collection;
 use Doctrine\MongoDB\Database;
 use Exception;
-use MongoTimestamp;
+use MongoDB\BSON\UTCDateTime;
 
 /**
  * @author Matthew Fitzgerald <matthewfitz@gmail.com>
@@ -382,11 +382,11 @@ class Version
     }
 
     /**
-     * @return MongoTimestamp
+     * @return UTCDateTime
      */
     protected function createMongoTimestamp()
     {
-        return new MongoTimestamp();
+        return new UTCDateTime();
     }
 
     /**

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationTest.php
@@ -65,7 +65,7 @@ class ConfigurationTest extends AntiMattrTestCase
             ->with('antimattr_migration_versions_test')
             ->will($this->returnValue($collection));
 
-        $cursor = $this->buildMock('MongoCursor');
+        $cursor = $this->buildMock('Doctrine\MongoDB\Cursor');
 
         $in = ['v' => ['$in' => ['20140822185742', '20140822185743', '20140822185744']]];
 
@@ -160,7 +160,7 @@ class ConfigurationTest extends AntiMattrTestCase
             ->with('antimattr_migration_versions_test')
             ->will($this->returnValue($collection));
 
-        $cursor = $this->buildMock('MongoCursor');
+        $cursor = $this->buildMock('Doctrine\MongoDB\Cursor');
 
         $collection->expects($this->once())
             ->method('find')

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
@@ -6,6 +6,7 @@ use AntiMattr\MongoDB\Migrations\AbstractMigration;
 use AntiMattr\MongoDB\Migrations\Version;
 use AntiMattr\TestCase\AntiMattrTestCase;
 use Doctrine\MongoDB\Database;
+use MongoDB\BSON\UTCDateTime;
 
 class VersionTest extends AntiMattrTestCase
 {
@@ -99,7 +100,7 @@ class VersionTest extends AntiMattrTestCase
 
     public function testMarkMigrated()
     {
-        $timestamp = $this->buildMock('MongoTimestamp');
+        $timestamp = new UTCDateTime();
         $this->version->setTimestamp($timestamp);
 
         $collection = $this->buildMock('Doctrine\MongoDB\Collection');
@@ -124,7 +125,7 @@ class VersionTest extends AntiMattrTestCase
 
     public function testMarkMigratedWithReplay()
     {
-        $timestamp = $this->buildMock('MongoTimestamp');
+        $timestamp = new UTCDateTime();
         $this->version->setTimestamp($timestamp);
 
         $collection = $this->buildMock('Doctrine\MongoDB\Collection');
@@ -154,7 +155,7 @@ class VersionTest extends AntiMattrTestCase
 
     public function testMarkNotMigrated()
     {
-        $timestamp = $this->buildMock('MongoTimestamp');
+        $timestamp = new UTCDateTime();
         $this->version->setTimestamp($timestamp);
 
         $collection = $this->buildMock('Doctrine\MongoDB\Collection');

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
@@ -54,7 +54,7 @@ class VersionTest extends AntiMattrTestCase
         $this->assertNotNull($this->version->getMigration());
     }
 
-    public function testAnalyzeThrowsMongoException()
+    public function testAnalyzeThrowsException()
     {
         $collection = $this->buildMock('Doctrine\MongoDB\Collection');
         $this->statistics->expects($this->once())
@@ -65,7 +65,7 @@ class VersionTest extends AntiMattrTestCase
             ->method('getName')
             ->will($this->returnValue('test_name'));
 
-        $expectedException = new \MongoException();
+        $expectedException = new \RuntimeException();
 
         $this->statistics->expects($this->once())
             ->method('updateBefore')
@@ -176,14 +176,14 @@ class VersionTest extends AntiMattrTestCase
         $this->version->markNotMigrated();
     }
 
-    public function testUpdateStatisticsAfterThrowsMongoException()
+    public function testUpdateStatisticsAfterThrowsException()
     {
         $collection = $this->buildMock('Doctrine\MongoDB\Collection');
         $this->statistics->expects($this->once())
             ->method('setCollection')
             ->with($collection);
 
-        $expectedException = new \MongoException();
+        $expectedException = new \RuntimeException();
 
         $this->statistics->expects($this->once())
             ->method('updateAfter')


### PR DESCRIPTION
Towards #22 

It turns out we only use the Doctrine classes apart from some unit tests. These were updated to also use the Doctrine classes. There isn't any advantage with testing with `\MongoException` as the new driver just extends `\RuntimeException'.