### PR TITLE
Fix issue with default action continuing the commands

### DIFF
--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -69,8 +69,8 @@ EOT
             $version->execute($direction, $replay);
         } else {
             $question = new ConfirmationQuestion(
-                '<question>WARNING! You are about to execute a database migration that could result in data lost. Are you sure you wish to continue? (y/n)</question> ',
-                'n'
+                '<question>WARNING! You are about to execute a database migration that could result in data lost. Are you sure you wish to continue? (y/[n])</question> ',
+                false
             );
 
             $confirmation = $this

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -83,8 +83,8 @@ EOT
 
             if (!$noInteraction) {
                 $question = new ConfirmationQuestion(
-                    '<question>Are you sure you wish to continue? (y/n)</question> ',
-                    'n'
+                    '<question>Are you sure you wish to continue? (y/[n])</question> ',
+                    false
                 );
 
                 $confirmation = $this
@@ -102,8 +102,8 @@ EOT
         // warn the user if no dry run and interaction is on
         if (!$noInteraction) {
             $question = new ConfirmationQuestion(
-                '<question>WARNING! You are about to execute a database migration that could result in data lost. Are you sure you wish to continue? (y/n)</question> ',
-                'n'
+                '<question>WARNING! You are about to execute a database migration that could result in data lost. Are you sure you wish to continue? (y/[n])</question> ',
+                false
             );
 
             $confirmation = $this


### PR DESCRIPTION
The constructor on `ConfirmationQuestion` takes a boolean as a second parameter. The `Migrate` and `Execute` commands have been passing a string `'n'`.

See https://github.com/symfony/console/blob/master/Question/ConfirmationQuestion.php#L28

The intent is to abort by default, but the string `'n'` can be considered truthy.

This PR clears up the confusion. The default is `'n'` if you press `Enter` during interactive prompt.