### PR TITLE
Fix/cleanup scrutinizer issues

### DIFF
--- a/src/AntiMattr/MongoDB/Migrations/AbstractMigration.php
+++ b/src/AntiMattr/MongoDB/Migrations/AbstractMigration.php
@@ -33,16 +33,6 @@ abstract class AbstractMigration
     private $outputWriter;
 
     /**
-     * @var Doctrine\MongoDB\Connection
-     */
-    protected $connection;
-
-    /**
-     * @var Doctrine\MongoDB\Database
-     */
-    protected $db;
-
-    /**
      * @var AntiMattr\MongoDB\Migrations\Version
      */
     protected $version;
@@ -51,10 +41,6 @@ abstract class AbstractMigration
     {
         $this->configuration = $version->getConfiguration();
         $this->outputWriter = $this->configuration->getOutputWriter();
-        $this->connection = $this->configuration->getConnection();
-        $this->connection = $this->connection->selectDatabase(
-            $this->configuration->getMigrationsDatabaseName()
-        );
         $this->version = $version;
     }
 

--- a/src/AntiMattr/MongoDB/Migrations/AbstractMigration.php
+++ b/src/AntiMattr/MongoDB/Migrations/AbstractMigration.php
@@ -23,17 +23,17 @@ use Doctrine\MongoDB\Database;
 abstract class AbstractMigration
 {
     /**
-     * @var AntiMattr\MongoDB\Migrations\Configuration\Configuration
+     * @var \AntiMattr\MongoDB\Migrations\Configuration\Configuration
      */
     private $configuration;
 
     /**
-     * @var AntiMattr\MongoDB\Migrations\OutputWriter
+     * @var \AntiMattr\MongoDB\Migrations\OutputWriter
      */
     private $outputWriter;
 
     /**
-     * @var AntiMattr\MongoDB\Migrations\Version
+     * @var \AntiMattr\MongoDB\Migrations\Version
      */
     protected $version;
 
@@ -56,7 +56,7 @@ abstract class AbstractMigration
     abstract public function down(Database $db);
 
     /**
-     * @param Doctrine\MongoDB\Collection
+     * @param \Doctrine\MongoDB\Collection
      */
     protected function analyze(Collection $collection)
     {
@@ -64,7 +64,7 @@ abstract class AbstractMigration
     }
 
     /**
-     * @param Doctrine\MongoDB\Database
+     * @param \Doctrine\MongoDB\Database
      * @param string $filename
      */
     protected function executeScript(Database $db, $filename)

--- a/src/AntiMattr/MongoDB/Migrations/Collection/Statistics.php
+++ b/src/AntiMattr/MongoDB/Migrations/Collection/Statistics.php
@@ -42,7 +42,7 @@ class Statistics
     ];
 
     /**
-     * @var Doctrine\MongoDB\Collection
+     * @var \Doctrine\MongoDB\Collection
      */
     private $collection;
 
@@ -57,7 +57,7 @@ class Statistics
     private $after = [];
 
     /**
-     * @param Doctrine\MongoDB\Collection
+     * @param \Doctrine\MongoDB\Collection
      */
     public function setCollection(Collection $collection)
     {
@@ -65,7 +65,7 @@ class Statistics
     }
 
     /**
-     * @return Doctrine\MongoDB\Collection
+     * @return \Doctrine\MongoDB\Collection
      */
     public function getCollection()
     {

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
@@ -25,22 +25,22 @@ use Doctrine\MongoDB\Database;
 class Configuration
 {
     /**
-     * @var Doctrine\MongoDB\Collection
+     * @var \Doctrine\MongoDB\Collection
      */
     private $collection;
 
     /**
-     * @var Doctrine\MongoDB\Connection
+     * @var \Doctrine\MongoDB\Connection
      */
     private $connection;
 
     /**
-     * @var Doctrine\MongoDB\Database
+     * @var \Doctrine\MongoDB\Database
      */
     private $database;
 
     /**
-     * @var Doctrine\MongoDB\Connection
+     * @var \Doctrine\MongoDB\Connection
      */
     private $migrationsDatabase;
 
@@ -94,18 +94,18 @@ class Configuration
     private $name;
 
     /**
-     * @var AntiMattr\MongoDB\Migrations\Version[]
+     * @var \AntiMattr\MongoDB\Migrations\Version[]
      */
     protected $migrations = [];
 
     /**
-     * @var AntiMattr\MongoDB\Migrations\OutputWriter
+     * @var \AntiMattr\MongoDB\Migrations\OutputWriter
      */
     private $outputWriter;
 
     /**
-     * @param Doctrine\MongoDB\Connection               $connection
-     * @param AntiMattr\MongoDB\Migrations\OutputWriter $outputWriter
+     * @param \Doctrine\MongoDB\Connection               $connection
+     * @param \AntiMattr\MongoDB\Migrations\OutputWriter $outputWriter
      */
     public function __construct(Connection $connection, OutputWriter $outputWriter = null)
     {
@@ -151,7 +151,7 @@ class Configuration
     }
 
     /**
-     * @return Doctrine\MongoDB\Collection
+     * @return \Doctrine\MongoDB\Collection
      */
     public function getCollection()
     {
@@ -165,7 +165,7 @@ class Configuration
     }
 
     /**
-     * @return Doctrine\MongoDB\Connection
+     * @return \Doctrine\MongoDB\Connection
      */
     public function getConnection()
     {
@@ -173,7 +173,7 @@ class Configuration
     }
 
     /**
-     * @return Doctrine\MongoDB\Database
+     * @return \Doctrine\MongoDB\Database
      */
     public function getDatabase(): ?Database
     {
@@ -281,7 +281,7 @@ class Configuration
     /**
      * Returns all migrated versions from the versions collection, in an array.
      *
-     * @return AntiMattr\MongoDB\Migrations\Version[]
+     * @return \AntiMattr\MongoDB\Migrations\Version[]
      */
     public function getMigratedVersions()
     {
@@ -379,7 +379,7 @@ class Configuration
     }
 
     /**
-     * @return AntiMattr\MongoDB\Migrations\OutputWriter
+     * @return \AntiMattr\MongoDB\Migrations\OutputWriter
      */
     public function getOutputWriter()
     {
@@ -468,7 +468,7 @@ class Configuration
      *
      * @param string $version The version string in the format YYYYMMDDHHMMSS
      *
-     * @return AntiMattr\MongoDB\Migrations\Version
+     * @return \AntiMattr\MongoDB\Migrations\Version
      *
      * @throws AntiMattr\MongoDB\Migrations\Exception\UnknownVersionException Throws exception if migration version does not exist
      */
@@ -496,7 +496,7 @@ class Configuration
     /**
      * Check if a version has been migrated or not yet.
      *
-     * @param AntiMattr\MongoDB\Migrations\Version $version
+     * @param \AntiMattr\MongoDB\Migrations\Version $version
      *
      * @return bool
      */

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
@@ -301,12 +301,12 @@ class Configuration
      *
      * @param string $version
      *
-     * @return string
+     * @return int
      *
      * @throws AntiMattr\MongoDB\Migrations\Exception\UnknownVersionException Throws exception if migration version does not exist
      * @throws DomainException                                                If more than one version exists
      */
-    public function getMigratedTimestamp($version)
+    public function getMigratedTimestamp($version): int
     {
         $this->createMigrationCollection();
 
@@ -329,7 +329,7 @@ class Configuration
         // Convert to normalised timestamp
         $ts = new Timestamp($returnVersion['t']);
 
-        return (string) $ts;
+        return $ts->getTimestamp();
     }
 
     /**
@@ -517,7 +517,7 @@ class Configuration
         $this->createMigrationCollection();
 
         $migratedVersions = [];
-        if ($this->migrations) {
+        if (!empty($this->migrations)) {
             foreach ($this->migrations as $migration) {
                 $migratedVersions[] = $migration->getVersion();
             }

--- a/src/AntiMattr/MongoDB/Migrations/Migration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Migration.php
@@ -81,7 +81,7 @@ class Migration
 
         $time = 0;
         foreach ($migrationsToExecute as $version) {
-            $versionSql = $version->execute($direction);
+            $version->execute($direction);
             $time += $version->getTime();
         }
 

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 abstract class AbstractCommand extends Command
 {
     /**
-     * @var AntiMattr\MongoDB\Migrations\Configuration\Configuration
+     * @var \AntiMattr\MongoDB\Migrations\Configuration\Configuration
      */
     private $configuration;
 
@@ -43,8 +43,8 @@ abstract class AbstractCommand extends Command
     }
 
     /**
-     * @param AntiMattr\MongoDB\Migrations\Configuration\Configuration
-     * @param Symfony\Component\Console\Output\OutputInterface
+     * @param \AntiMattr\MongoDB\Migrations\Configuration\Configuration $configuration
+     * @param \Symfony\Component\Console\Output\OutputInterface         $output
      */
     protected function outputHeader(Configuration $configuration, OutputInterface $output)
     {
@@ -58,7 +58,7 @@ abstract class AbstractCommand extends Command
     }
 
     /**
-     * @param AntiMattr\MongoDB\Migrations\Configuration\Configuration
+     * @param \AntiMattr\MongoDB\Migrations\Configuration\Configuration
      */
     public function setMigrationConfiguration(Configuration $config)
     {
@@ -66,10 +66,10 @@ abstract class AbstractCommand extends Command
     }
 
     /**
-     * @param Symfony\Component\Console\Output\InputInterface  $input
-     * @param Symfony\Component\Console\Output\OutputInterface $output
+     * @param \Symfony\Component\Console\Output\InputInterface  $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      *
-     * @return AntiMattr\MongoDB\Migrations\Configuration\Configuration
+     * @return \AntiMattr\MongoDB\Migrations\Configuration\Configuration
      */
     protected function getMigrationConfiguration(InputInterface $input, OutputInterface $output)
     {
@@ -112,9 +112,9 @@ abstract class AbstractCommand extends Command
     }
 
     /**
-     * @params array $params
+     * @param array $params
      *
-     * @return Doctrine\MongoDB\Connection
+     * @return \Doctrine\MongoDB\Connection
      */
     protected function createConnection($params)
     {

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -66,7 +66,7 @@ abstract class AbstractCommand extends Command
     }
 
     /**
-     * @param \Symfony\Component\Console\Output\InputInterface  $input
+     * @param \Symfony\Component\Console\Input\InputInterface   $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      *
      * @return \AntiMattr\MongoDB\Migrations\Configuration\Configuration

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -53,8 +53,8 @@ EOT
     }
 
     /**
-     * @param Symfony\Component\Console\Input\InputInterface
-     * @param Symfony\Component\Console\Output\OutputInterface
+     * @param \Symfony\Component\Console\Input\InputInterface
+     * @param \Symfony\Component\Console\Output\OutputInterface
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -79,8 +79,8 @@ EOT
     }
 
     /**
-     * @param Symfony\Component\Console\Input\InputInterface
-     * @param Symfony\Component\Console\Output\OutputInterface
+     * @param \Symfony\Component\Console\Input\InputInterface
+     * @param \Symfony\Component\Console\Output\OutputInterface
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
@@ -93,8 +93,8 @@ EOT
     }
 
     /**
-     * @param AntiMattr\MongoDB\Migrations\Configuration\Configuration
-     * @param Symfony\Component\Console\Input\InputInterface
+     * @param \AntiMattr\MongoDB\Migrations\Configuration\Configuration
+     * @param \Symfony\Component\Console\Input\InputInterface
      * @param string $version
      * @param string $up
      * @param string $down

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -51,8 +51,8 @@ EOT
     }
 
     /**
-     * @param Symfony\Component\Console\Input\InputInterface
-     * @param Symfony\Component\Console\Output\OutputInterface
+     * @param \Symfony\Component\Console\Input\InputInterface
+     * @param \Symfony\Component\Console\Output\OutputInterface
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
@@ -146,7 +146,7 @@ EOT
             }
 
             $executedUnavailableMigrations = $configuration->getUnavailableMigratedVersions();
-            if ($executedUnavailableMigrations) {
+            if (!empty($executedUnavailableMigrations)) {
                 $output->writeln("\n <info>==</info> Previously Executed Unavailable Migration Versions\n");
                 foreach ($executedUnavailableMigrations as $executedUnavailableMigration) {
                     $output->writeln(

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/StatusCommand.php
@@ -52,8 +52,8 @@ EOT
     }
 
     /**
-     * @param Symfony\Component\Console\Input\InputInterface
-     * @param Symfony\Component\Console\Output\OutputInterface
+     * @param \Symfony\Component\Console\Input\InputInterface
+     * @param \Symfony\Component\Console\Output\OutputInterface
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/VersionCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/VersionCommand.php
@@ -49,8 +49,8 @@ EOT
     }
 
     /**
-     * @param Symfony\Component\Console\Input\InputInterface
-     * @param Symfony\Component\Console\Output\OutputInterface
+     * @param \Symfony\Component\Console\Input\InputInterface
+     * @param \Symfony\Component\Console\Output\OutputInterface
      *
      * @throws AntiMattr\MongoDB\Migrations\Exception\UnknownVersionException Throws exception if migration version does not exist
      * @throws InvalidArgumentException

--- a/src/AntiMattr/MongoDB/Migrations/Version.php
+++ b/src/AntiMattr/MongoDB/Migrations/Version.php
@@ -36,22 +36,22 @@ class Version
     private $class;
 
     /**
-     * @var AntiMattr\MongoDB\Migrations\Configuration\Configuration
+     * @var \AntiMattr\MongoDB\Migrations\Configuration\Configuration
      */
     private $configuration;
 
     /**
-     * @var Doctrine\MongoDB\Connection
+     * @var \Doctrine\MongoDB\Connection
      */
     private $connection;
 
     /**
-     * @var AntiMattr\MongoDB\Migrations\AbstractMigration
+     * @var \AntiMattr\MongoDB\Migrations\AbstractMigration
      */
     protected $migration;
 
     /**
-     * @var AntiMattr\MongoDB\Migrations\OutputWriter
+     * @var \AntiMattr\MongoDB\Migrations\OutputWriter
      */
     private $outputWriter;
 
@@ -63,7 +63,7 @@ class Version
     private $version;
 
     /**
-     * @var AntiMattr\MongoDB\Migrations\Collection\Statistics[]
+     * @var \AntiMattr\MongoDB\Migrations\Collection\Statistics[]
      */
     private $statistics = [];
 
@@ -89,7 +89,7 @@ class Version
     }
 
     /**
-     * @return AntiMattr\MongoDB\Migrations\Configuration\Configuration $configuration
+     * @return \AntiMattr\MongoDB\Migrations\Configuration\Configuration $configuration
      */
     public function getConfiguration()
     {
@@ -111,7 +111,7 @@ class Version
     }
 
     /**
-     * @return AntiMattr\MongoDB\Migrations\AbstractMigration
+     * @return \AntiMattr\MongoDB\Migrations\AbstractMigration
      */
     public function getMigration()
     {
@@ -145,7 +145,7 @@ class Version
     }
 
     /**
-     * @param Doctrine\MongoDB\Collection
+     * @param \Doctrine\MongoDB\Collection
      */
     public function analyze(Collection $collection)
     {
@@ -244,7 +244,7 @@ class Version
     }
 
     /**
-     * @param Doctrine\MongoDB\Database
+     * @param \Doctrine\MongoDB\Database
      * @param string $file
      *
      * @return array
@@ -374,7 +374,7 @@ class Version
     }
 
     /**
-     * @return AntiMattr\MongoDB\Migrations\AbstractMigration
+     * @return \AntiMattr\MongoDB\Migrations\AbstractMigration
      */
     protected function createMigration()
     {
@@ -390,7 +390,7 @@ class Version
     }
 
     /**
-     * @return AntiMattr\MongoDB\Migrations\Collection\Statistics
+     * @return \AntiMattr\MongoDB\Migrations\Collection\Statistics
      */
     protected function createStatistics()
     {

--- a/src/AntiMattr/MongoDB/Migrations/Version.php
+++ b/src/AntiMattr/MongoDB/Migrations/Version.php
@@ -167,7 +167,7 @@ class Version
     }
 
     /**
-     * Execute this migration version up or down and and return the SQL.
+     * Execute this migration version up or down
      *
      * @param string $direction The direction to execute the migration
      * @param bool   $replay    If the migration is being replayed


### PR DESCRIPTION
Scrutinizer has a lot of errors due to incorrectly identifying classes via typehint/docblock.

Sorry, this includes the previous PR #36  - can re-make this if we don't choose to merge #36.
