### PR TITLE
Use mongodb/mongodb instead of doctrine/mongodb

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": "^7.1",
-        "mongodb/mongodb": "^1.0",
+        "mongodb/mongodb": "^1.4",
         "symfony/console": "^2.7|^3.3|^4",
         "symfony/yaml": "^2.7|^3.3|^4"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "php": "^7.1",
         "ext-mongodb": "*",
         "mongodb/mongodb": "^1.4",
-        "symfony/console": "^2.7|^3.3|^4",
-        "symfony/yaml": "^2.7|^3.3|^4"
+        "symfony/console": "^3.4|^4",
+        "symfony/yaml": "^3.4|^4"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     },
     "require": {
         "php": "^7.1",
+        "ext-mongodb": "*",
         "mongodb/mongodb": "^1.4",
         "symfony/console": "^2.7|^3.3|^4",
         "symfony/yaml": "^2.7|^3.3|^4"

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "php": "^7.1",
         "ext-mongodb": "*",
         "mongodb/mongodb": "^1.4",
-        "symfony/console": "^3.4|^4",
-        "symfony/yaml": "^3.4|^4"
+        "symfony/console": "^2.7|^3.4|^4",
+        "symfony/yaml": "^2.7|^3.4|^4"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": "^7.1",
-        "doctrine/mongodb": "^1.0",
+        "mongodb/mongodb": "^1.0",
         "symfony/console": "^2.7|^3.3|^4",
         "symfony/yaml": "^2.7|^3.3|^4"
     },

--- a/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185742.php
+++ b/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185742.php
@@ -20,7 +20,7 @@ class Version20140822185742 extends AbstractMigration
         $testA = $db->selectCollection('test_a');
         $this->analyze($testA);
 
-        $testA->ensureIndex(['actor' => -1]);
+        $testA->createIndex(['actor' => -1]);
     }
 
     public function down(Database $db)
@@ -48,7 +48,7 @@ class Version20140822185742 extends AbstractMigration
             $testDocuments[] = $testDocument;
         }
 
-        $testA->batchInsert($testDocuments);
+        $testA->insertMany($testDocuments);
     }
 
     /**

--- a/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185742.php
+++ b/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185742.php
@@ -3,7 +3,7 @@
 namespace Example\Migrations\TestAntiMattr\MongoDB;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use \MongoDB\Database;
 
 class Version20140822185742 extends AbstractMigration
 {

--- a/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185743.php
+++ b/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185743.php
@@ -3,7 +3,7 @@
 namespace Example\Migrations\TestAntiMattr\MongoDB;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use \MongoDB\Database;
 
 class Version20140822185743 extends AbstractMigration
 {

--- a/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185743.php
+++ b/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185743.php
@@ -49,7 +49,7 @@ class Version20140822185743 extends AbstractMigration
             $testDocuments[] = $testDocument;
         }
 
-        $testA->batchInsert($testDocuments);
+        $testA->insertMany($testDocuments);
     }
 
     /**

--- a/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185744.php
+++ b/demo/ConsoleApplication/Example/Migrations/TestAntiMattr/MongoDB/Version20140822185744.php
@@ -3,7 +3,7 @@
 namespace Example\Migrations\TestAntiMattr\MongoDB;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use \MongoDB\Database;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,9 +10,5 @@
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">src</directory>
         </whitelist>
-        <blacklist>
-            <directory>vendor</directory>
-            <directory>./tests</directory>
-        </blacklist>
     </filter>
 </phpunit>

--- a/src/AntiMattr/MongoDB/Migrations/AbstractMigration.php
+++ b/src/AntiMattr/MongoDB/Migrations/AbstractMigration.php
@@ -56,7 +56,7 @@ abstract class AbstractMigration
     abstract public function down(Database $db);
 
     /**
-     * @param \Doctrine\MongoDB\Collection
+     * @param \MongoDB\Collection
      */
     protected function analyze(Collection $collection)
     {
@@ -64,7 +64,7 @@ abstract class AbstractMigration
     }
 
     /**
-     * @param \Doctrine\MongoDB\Database
+     * @param \MongoDB\Database
      * @param string $filename
      */
     protected function executeScript(Database $db, $filename)

--- a/src/AntiMattr/MongoDB/Migrations/AbstractMigration.php
+++ b/src/AntiMattr/MongoDB/Migrations/AbstractMigration.php
@@ -14,8 +14,8 @@ namespace AntiMattr\MongoDB\Migrations;
 use AntiMattr\MongoDB\Migrations\Exception\AbortException;
 use AntiMattr\MongoDB\Migrations\Exception\IrreversibleException;
 use AntiMattr\MongoDB\Migrations\Exception\SkipException;
-use Doctrine\MongoDB\Collection;
-use Doctrine\MongoDB\Database;
+use \MongoDB\Collection;
+use \MongoDB\Database;
 
 /**
  * @author Matthew Fitzgerald <matthewfitz@gmail.com>

--- a/src/AntiMattr/MongoDB/Migrations/Collection/Statistics.php
+++ b/src/AntiMattr/MongoDB/Migrations/Collection/Statistics.php
@@ -131,14 +131,6 @@ class Statistics
             throw new Exception($message);
         }
 
-        /* new MongoDB\Driver\Cursor does not have an errmsg, it throws exceptions itself */
-        /* Disabled for now @todo what to do with this? */
-        /*
-        if (isset($data['errmsg'])) {
-            throw new Exception($data['errmsg']);
-        }
-        */
-
         return $data;
     }
 }

--- a/src/AntiMattr/MongoDB/Migrations/Collection/Statistics.php
+++ b/src/AntiMattr/MongoDB/Migrations/Collection/Statistics.php
@@ -13,6 +13,7 @@ namespace AntiMattr\MongoDB\Migrations\Collection;
 
 use \MongoDB\Collection;
 use Exception;
+use MongoDB\Database;
 
 /**
  * @author Matthew Fitzgerald <matthewfitz@gmail.com>
@@ -55,6 +56,11 @@ class Statistics
      * @var array
      */
     private $after = [];
+
+    public function setDatabase(Database $database)
+    {
+        $this->database = $database;
+    }
 
     /**
      * @param \MongoDB\Collection
@@ -115,10 +121,9 @@ class Statistics
      */
     protected function getCollectionStats()
     {
-        $database = $this->collection->getDatabase();
-        $name = $this->collection->getName();
+        $name = $this->collection->getCollectionName();
 
-        if (!$data = $database->command(['collStats' => $name])) {
+        if (!$data = $this->database->command(['collStats' => $name])) {
             $message = sprintf(
                 'Statistics not found for collection %s',
                 $name

--- a/src/AntiMattr/MongoDB/Migrations/Collection/Statistics.php
+++ b/src/AntiMattr/MongoDB/Migrations/Collection/Statistics.php
@@ -11,7 +11,7 @@
 
 namespace AntiMattr\MongoDB\Migrations\Collection;
 
-use Doctrine\MongoDB\Collection;
+use \MongoDB\Collection;
 use Exception;
 
 /**
@@ -42,7 +42,7 @@ class Statistics
     ];
 
     /**
-     * @var \Doctrine\MongoDB\Collection
+     * @var \MongoDB\Collection
      */
     private $collection;
 
@@ -57,7 +57,7 @@ class Statistics
     private $after = [];
 
     /**
-     * @param \Doctrine\MongoDB\Collection
+     * @param \MongoDB\Collection
      */
     public function setCollection(Collection $collection)
     {
@@ -65,7 +65,7 @@ class Statistics
     }
 
     /**
-     * @return \Doctrine\MongoDB\Collection
+     * @return \MongoDB\Collection
      */
     public function getCollection()
     {

--- a/src/AntiMattr/MongoDB/Migrations/Collection/Statistics.php
+++ b/src/AntiMattr/MongoDB/Migrations/Collection/Statistics.php
@@ -131,9 +131,13 @@ class Statistics
             throw new Exception($message);
         }
 
+        /* new MongoDB\Driver\Cursor does not have an errmsg, it throws exceptions itself */
+        /* Disabled for now @todo what to do with this? */
+        /*
         if (isset($data['errmsg'])) {
             throw new Exception($data['errmsg']);
         }
+        */
 
         return $data;
     }

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
@@ -558,12 +558,12 @@ class Configuration
                 ['sort' => ['v' => -1], 'limit' => 1]
             );
 
-        if (0 === \count($cursor->toArray())) {
+        $versions = $cursor->toArray();
+        if (0 === \count($versions)) {
             return '0';
         }
 
-        $version = $cursor->getNext();
-
+        $version = $versions[0];
         return $version['v'];
     }
 

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
@@ -16,8 +16,7 @@ use AntiMattr\MongoDB\Migrations\Exception\DuplicateVersionException;
 use AntiMattr\MongoDB\Migrations\Exception\UnknownVersionException;
 use AntiMattr\MongoDB\Migrations\OutputWriter;
 use AntiMattr\MongoDB\Migrations\Version;
-use Doctrine\MongoDB\Connection;
-use Doctrine\MongoDB\Database;
+use MongoDB\Client;
 
 /**
  * @author Matthew Fitzgerald <matthewfitz@gmail.com>
@@ -25,24 +24,19 @@ use Doctrine\MongoDB\Database;
 class Configuration
 {
     /**
-     * @var \Doctrine\MongoDB\Collection
+     * @var \MongoDB\Collection
      */
     private $collection;
 
     /**
-     * @var \Doctrine\MongoDB\Connection
+     * @var \MongoDB\Client
      */
     private $connection;
 
     /**
-     * @var \Doctrine\MongoDB\Database
+     * @var \MongoDB\Database
      */
     private $database;
-
-    /**
-     * @var \Doctrine\MongoDB\Connection
-     */
-    private $migrationsDatabase;
 
     /**
      * The migration database name to track versions in.
@@ -109,10 +103,10 @@ class Configuration
     private $file;
 
     /**
-     * @param \Doctrine\MongoDB\Connection               $connection
+     * @param \MongoDB\Client               $connection
      * @param \AntiMattr\MongoDB\Migrations\OutputWriter $outputWriter
      */
-    public function __construct(Connection $connection, OutputWriter $outputWriter = null)
+    public function __construct(Client $connection, OutputWriter $outputWriter = null)
     {
         $this->connection = $connection;
         if (null === $outputWriter) {
@@ -156,7 +150,7 @@ class Configuration
     }
 
     /**
-     * @return \Doctrine\MongoDB\Collection
+     * @return \MongoDB\Collection
      */
     public function getCollection()
     {
@@ -170,7 +164,7 @@ class Configuration
     }
 
     /**
-     * @return \Doctrine\MongoDB\Connection
+     * @return \MongoDB\Client
      */
     public function getConnection()
     {
@@ -178,9 +172,9 @@ class Configuration
     }
 
     /**
-     * @return \Doctrine\MongoDB\Database
+     * @return \MongoDB\Database
      */
-    public function getDatabase(): ?Database
+    public function getDatabase(): ?\MongoDB\Database
     {
         if (isset($this->database)) {
             return $this->database;
@@ -560,12 +554,11 @@ class Configuration
 
         $cursor = $this->getCollection()
             ->find(
-                ['v' => ['$in' => $migratedVersions]]
-            )
-            ->sort(['v' => -1])
-            ->limit(1);
+                ['v' => ['$in' => $migratedVersions]],
+                ['sort' => ['v' => -1], 'limit' => 1]
+            );
 
-        if (0 === $cursor->count()) {
+        if (0 === \count($cursor->toArray())) {
             return '0';
         }
 
@@ -598,7 +591,7 @@ class Configuration
 
         if (true !== $this->migrationCollectionCreated) {
             $collection = $this->getCollection();
-            $collection->ensureIndex(['v' => -1], ['name' => 'version', 'unique' => true]);
+            $collection->createIndex(['v' => -1], ['name' => 'version', 'unique' => true]);
             $this->migrationCollectionCreated = true;
         }
 

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
@@ -341,17 +341,18 @@ class Configuration
             ['v' => $version]
         );
 
-        if (!$cursor->count()) {
+        $result = $cursor->toArray();
+        if (!count($result)) {
             throw new UnknownVersionException($version);
         }
 
-        if ($cursor->count() > 1) {
+        if (count($result) > 1) {
             throw new \DomainException(
                 'Unexpected duplicate version records in the database'
             );
         }
 
-        $returnVersion = $cursor->getNext();
+        $returnVersion = $result[0];
 
         // Convert to normalised timestamp
         $ts = new Timestamp($returnVersion['t']);

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
@@ -403,9 +403,7 @@ class Configuration
     {
         $this->createMigrationCollection();
 
-        $cursor = $this->getCollection()->find();
-
-        return $cursor->count();
+        return $this->getCollection()->countDocuments();
     }
 
     /**

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/ConfigurationBuilder.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/ConfigurationBuilder.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace AntiMattr\MongoDB\Migrations\Configuration;
 
 use AntiMattr\MongoDB\Migrations\OutputWriter;
-use Doctrine\MongoDB\Connection;
 use MongoDB\Client;
 use Symfony\Component\Yaml\Yaml;
 
@@ -65,7 +64,7 @@ class ConfigurationBuilder
     }
 
     /**
-     * @param Connection $connection
+     * @param Client $connection
      *
      * @return ConfigurationBuilder
      */

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/ConfigurationBuilder.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/ConfigurationBuilder.php
@@ -15,6 +15,7 @@ namespace AntiMattr\MongoDB\Migrations\Configuration;
 
 use AntiMattr\MongoDB\Migrations\OutputWriter;
 use Doctrine\MongoDB\Connection;
+use MongoDB\Client;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -23,7 +24,7 @@ use Symfony\Component\Yaml\Yaml;
 class ConfigurationBuilder
 {
     /**
-     * @var \Doctrine\MongoDB\Connection
+     * @var \MongoDB\Client
      */
     private $connection;
 
@@ -68,7 +69,7 @@ class ConfigurationBuilder
      *
      * @return ConfigurationBuilder
      */
-    public function setConnection(Connection $connection): ConfigurationBuilder
+    public function setConnection(Client $connection): ConfigurationBuilder
     {
         $this->connection = $connection;
 

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -15,6 +15,7 @@ use AntiMattr\MongoDB\Migrations\Configuration\Configuration;
 use AntiMattr\MongoDB\Migrations\Configuration\ConfigurationBuilder;
 use AntiMattr\MongoDB\Migrations\OutputWriter;
 use Doctrine\MongoDB\Connection;
+use MongoDB\Client;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -100,13 +101,13 @@ abstract class AbstractCommand extends Command
      *
      * @return Connection
      */
-    protected function getDatabaseConnection(InputInterface $input): Connection
+    protected function getDatabaseConnection(InputInterface $input): Client
     {
         // Default to document manager helper set
         if ($this->getApplication()->getHelperSet()->has('dm')) {
             return $this->getHelper('dm')
                 ->getDocumentManager()
-                ->getConnection();
+                ->getClient();
         }
 
         // PHP array file
@@ -166,6 +167,6 @@ abstract class AbstractCommand extends Command
             $options = $params['options'];
         }
 
-        return new Connection($server, $options);
+        return new Client($server, $options);
     }
 }

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -14,7 +14,6 @@ namespace AntiMattr\MongoDB\Migrations\Tools\Console\Command;
 use AntiMattr\MongoDB\Migrations\Configuration\Configuration;
 use AntiMattr\MongoDB\Migrations\Configuration\ConfigurationBuilder;
 use AntiMattr\MongoDB\Migrations\OutputWriter;
-use Doctrine\MongoDB\Connection;
 use MongoDB\Client;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -99,7 +98,7 @@ abstract class AbstractCommand extends Command
     /**
      * @param InputInterface $input
      *
-     * @return Connection
+     * @return Client
      */
     protected function getDatabaseConnection(InputInterface $input): Client
     {
@@ -137,7 +136,7 @@ abstract class AbstractCommand extends Command
     /**
      * @param array $params
      *
-     * @return \Doctrine\MongoDB\Connection
+     * @return \MongoDB\Client
      */
     protected function createConnection($params)
     {

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -29,7 +29,7 @@ class GenerateCommand extends AbstractCommand
 namespace <namespace>;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use MongoDB\Database;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/src/AntiMattr/MongoDB/Migrations/Version.php
+++ b/src/AntiMattr/MongoDB/Migrations/Version.php
@@ -41,11 +41,6 @@ class Version
     private $configuration;
 
     /**
-     * @var \MongoDB\Connection
-     */
-    private $connection;
-
-    /**
      * @var \MongoDB\Database
      */
     private $db;
@@ -87,7 +82,6 @@ class Version
         $this->configuration = $configuration;
         $this->outputWriter = $configuration->getOutputWriter();
         $this->class = $class;
-        $this->connection = $configuration->getConnection();
         $this->db = $configuration->getDatabase();
         $this->migration = $this->createMigration();
         $this->version = $version;
@@ -280,16 +274,7 @@ class Version
             throw $e;
         }
 
-        $result = $db->command(['$eval' => $js, 'nolock' => true]);
-
-        /* Command throws it's own exceptions if something is wrong, this errmsg no longer exists on MongoDB\DriverCursor
-          @todo what to do with this, disabled for now
-        if (isset($result['errmsg'])) {
-            throw new \Exception($result['errmsg'], isset($result['errno']) ? $result['errno'] : null);
-        }
-        */
-
-        return $result;
+        return $db->command(['$eval' => $js, 'nolock' => true]);
     }
 
     /**
@@ -379,7 +364,7 @@ class Version
 
     public function __toString()
     {
-        return $this->version;
+        return (string) $this->version;
     }
 
     /**

--- a/src/AntiMattr/MongoDB/Migrations/Version.php
+++ b/src/AntiMattr/MongoDB/Migrations/Version.php
@@ -307,7 +307,7 @@ class Version
             $options = ['upsert' => true];
             $collection->update($query, $document, $options);
         } else {
-            $collection->insert($document);
+            $collection->insertOne($document);
         }
     }
 

--- a/src/AntiMattr/MongoDB/Migrations/Version.php
+++ b/src/AntiMattr/MongoDB/Migrations/Version.php
@@ -155,6 +155,7 @@ class Version
     public function analyze(Collection $collection)
     {
         $statistics = $this->createStatistics();
+        $statistics->setDatabase($this->db);
         $statistics->setCollection($collection);
         $name = $collection->getCollectionName();
         $this->statistics[$name] = $statistics;
@@ -305,7 +306,7 @@ class Version
             // If the user asked for a 'replay' of a migration that
             // has not been run, it will be inserted anew
             $options = ['upsert' => true];
-            $collection->update($query, $document, $options);
+            $collection->updateOne($query, $document, $options);
         } else {
             $collection->insertOne($document);
         }
@@ -323,7 +324,7 @@ class Version
         foreach ($this->statistics as $name => $statistic) {
             try {
                 $statistic->updateAfter();
-                $name = $statistic->getCollection()->getName();
+                $name = $statistic->getCollection()->getCollectionName();
                 $this->statistics[$name] = $statistic;
             } catch (\Exception $e) {
                 $message = sprintf('     <info>Warning during %s: %s</info>',

--- a/src/AntiMattr/MongoDB/Migrations/Version.php
+++ b/src/AntiMattr/MongoDB/Migrations/Version.php
@@ -15,8 +15,8 @@ use AntiMattr\MongoDB\Migrations\Collection\Statistics;
 use AntiMattr\MongoDB\Migrations\Configuration\Configuration;
 use AntiMattr\MongoDB\Migrations\Exception\SkipException;
 use AntiMattr\MongoDB\Migrations\Exception\AbortException;
-use Doctrine\MongoDB\Collection;
-use Doctrine\MongoDB\Database;
+use \MongoDB\Collection;
+use \MongoDB\Database;
 use Exception;
 use MongoDB\BSON\UTCDateTime;
 
@@ -41,12 +41,12 @@ class Version
     private $configuration;
 
     /**
-     * @var \Doctrine\MongoDB\Connection
+     * @var \MongoDB\Connection
      */
     private $connection;
 
     /**
-     * @var \Doctrine\MongoDB\Database
+     * @var \MongoDB\Database
      */
     private $db;
 
@@ -150,7 +150,7 @@ class Version
     }
 
     /**
-     * @param \Doctrine\MongoDB\Collection
+     * @param \MongoDB\Collection
      */
     public function analyze(Collection $collection)
     {
@@ -249,7 +249,7 @@ class Version
     }
 
     /**
-     * @param \Doctrine\MongoDB\Database
+     * @param \MongoDB\Database
      * @param string $file
      *
      * @return array

--- a/src/AntiMattr/MongoDB/Migrations/Version.php
+++ b/src/AntiMattr/MongoDB/Migrations/Version.php
@@ -282,9 +282,12 @@ class Version
 
         $result = $db->command(['$eval' => $js, 'nolock' => true]);
 
+        /* Command throws it's own exceptions if something is wrong, this errmsg no longer exists on MongoDB\DriverCursor
+          @todo what to do with this, disabled for now
         if (isset($result['errmsg'])) {
             throw new \Exception($result['errmsg'], isset($result['errno']) ? $result['errno'] : null);
         }
+        */
 
         return $result;
     }

--- a/src/AntiMattr/MongoDB/Migrations/Version.php
+++ b/src/AntiMattr/MongoDB/Migrations/Version.php
@@ -156,7 +156,7 @@ class Version
     {
         $statistics = $this->createStatistics();
         $statistics->setCollection($collection);
-        $name = $collection->getName();
+        $name = $collection->getCollectionName();
         $this->statistics[$name] = $statistics;
 
         try {
@@ -315,7 +315,7 @@ class Version
     {
         $this->configuration->createMigrationCollection();
         $collection = $this->configuration->getCollection();
-        $collection->remove(['v' => $this->version]);
+        $collection->deleteOne(['v' => $this->version]);
     }
 
     protected function updateStatisticsAfter()

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Collection/StatisticsTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Collection/StatisticsTest.php
@@ -40,35 +40,6 @@ class StatisticsTest extends TestCase
         $this->statistics->doGetCollectionStats();
     }
 
-    /**
-     * @expectedException \Exception
-     */
-    public function testGetCollectionStatsThrowsExceptionWhenErrmsgFound()
-    {
-        $database = $this->createMock('MongoDB\Database');
-
-        $this->statistics = new StatisticsStub();
-        $this->statistics->setCollection($this->collection);
-        $this->statistics->setDatabase($database);
-
-        $this->collection->expects($this->once())
-            ->method('getCollectionName')
-            ->will($this->returnValue('example'));
-
-        $data = [
-            'errmsg' => 'foo',
-        ];
-
-        $database->expects($this->once())
-            ->method('command')
-            ->will($this->returnValue($data));
-
-        // Can't test it this way as it will return a MongoDB\Driver\Cursor which does not have a errmsg array
-        // @todo what do to do here, remove this test? 
-        //$this->statistics->doGetCollectionStats();
-        $this->markTestIncomplete('This method needs to act on a MongoDB\Driver\Cursor object which has no error method');
-    }
-
     public function testGetCollectionStats()
     {
         $database = $this->createMock('MongoDB\Database');

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Collection/StatisticsTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Collection/StatisticsTest.php
@@ -27,17 +27,14 @@ class StatisticsTest extends TestCase
      */
     public function testGetCollectionStatsThrowsExceptionWhenDataNotFound()
     {
-        $this->statistics = new StatisticsStub();
-        $this->statistics->setCollection($this->collection);
-
         $database = $this->createMock('MongoDB\Database');
 
-        $this->collection->expects($this->once())
-            ->method('getDatabase')
-            ->will($this->returnValue($database));
+        $this->statistics = new StatisticsStub();
+        $this->statistics->setCollection($this->collection);
+        $this->statistics->setDatabase($database);
 
         $this->collection->expects($this->once())
-            ->method('getName')
+            ->method('getCollectionName')
             ->will($this->returnValue('example'));
 
         $this->statistics->doGetCollectionStats();
@@ -48,17 +45,14 @@ class StatisticsTest extends TestCase
      */
     public function testGetCollectionStatsThrowsExceptionWhenErrmsgFound()
     {
-        $this->statistics = new StatisticsStub();
-        $this->statistics->setCollection($this->collection);
-
         $database = $this->createMock('MongoDB\Database');
 
-        $this->collection->expects($this->once())
-            ->method('getDatabase')
-            ->will($this->returnValue($database));
+        $this->statistics = new StatisticsStub();
+        $this->statistics->setCollection($this->collection);
+        $this->statistics->setDatabase($database);
 
         $this->collection->expects($this->once())
-            ->method('getName')
+            ->method('getCollectionName')
             ->will($this->returnValue('example'));
 
         $data = [
@@ -74,17 +68,14 @@ class StatisticsTest extends TestCase
 
     public function testGetCollectionStats()
     {
-        $this->statistics = new StatisticsStub();
-        $this->statistics->setCollection($this->collection);
-
         $database = $this->createMock('MongoDB\Database');
 
-        $this->collection->expects($this->once())
-            ->method('getDatabase')
-            ->will($this->returnValue($database));
+        $this->statistics = new StatisticsStub();
+        $this->statistics->setCollection($this->collection);
+        $this->statistics->setDatabase($database);
 
         $this->collection->expects($this->once())
-            ->method('getName')
+            ->method('getCollectionName')
             ->will($this->returnValue('example'));
 
         $expectedData = [

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Collection/StatisticsTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Collection/StatisticsTest.php
@@ -63,7 +63,10 @@ class StatisticsTest extends TestCase
             ->method('command')
             ->will($this->returnValue($data));
 
-        $this->statistics->doGetCollectionStats();
+        // Can't test it this way as it will return a MongoDB\Driver\Cursor which does not have a errmsg array
+        // @todo what do to do here, remove this test? 
+        //$this->statistics->doGetCollectionStats();
+        $this->markTestIncomplete('This method needs to act on a MongoDB\Driver\Cursor object which has no error method');
     }
 
     public function testGetCollectionStats()

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Collection/StatisticsTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Collection/StatisticsTest.php
@@ -12,7 +12,7 @@ class StatisticsTest extends TestCase
 
     protected function setUp()
     {
-        $this->collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $this->collection = $this->createMock('MongoDB\Collection');
         $this->statistics = new Statistics();
     }
 
@@ -30,7 +30,7 @@ class StatisticsTest extends TestCase
         $this->statistics = new StatisticsStub();
         $this->statistics->setCollection($this->collection);
 
-        $database = $this->createMock('Doctrine\MongoDB\Database');
+        $database = $this->createMock('MongoDB\Database');
 
         $this->collection->expects($this->once())
             ->method('getDatabase')
@@ -51,7 +51,7 @@ class StatisticsTest extends TestCase
         $this->statistics = new StatisticsStub();
         $this->statistics->setCollection($this->collection);
 
-        $database = $this->createMock('Doctrine\MongoDB\Database');
+        $database = $this->createMock('MongoDB\Database');
 
         $this->collection->expects($this->once())
             ->method('getDatabase')
@@ -77,7 +77,7 @@ class StatisticsTest extends TestCase
         $this->statistics = new StatisticsStub();
         $this->statistics->setCollection($this->collection);
 
-        $database = $this->createMock('Doctrine\MongoDB\Database');
+        $database = $this->createMock('MongoDB\Database');
 
         $this->collection->expects($this->once())
             ->method('getDatabase')

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationBuilderTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationBuilderTest.php
@@ -11,7 +11,7 @@ class ConfigurationBuilderTest extends TestCase
 {
     public function testBuildingConfiguration()
     {
-        $conn = $this->createMock('Doctrine\MongoDB\Connection');
+        $conn = $this->createMock('MongoDB\Client');
         $outputWriter = new OutputWriter();
         $onDiskConfig = '';
 
@@ -28,7 +28,7 @@ class ConfigurationBuilderTest extends TestCase
 
     public function testBuildingWithYamlConfig()
     {
-        $conn = $this->createMock('Doctrine\MongoDB\Connection');
+        $conn = $this->createMock('MongoDB\Client');
         $outputWriter = new OutputWriter();
         $onDiskConfig = dirname(__DIR__) . '/Resources/fixtures/config.yml';
 
@@ -52,7 +52,7 @@ class ConfigurationBuilderTest extends TestCase
 
     public function testBuildingWithXmlConfig()
     {
-        $conn = $this->createMock('Doctrine\MongoDB\Connection');
+        $conn = $this->createMock('MongoDB\Client');
         $outputWriter = new OutputWriter();
         $onDiskConfig = dirname(__DIR__) . '/Resources/fixtures/config.xml';
 

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationTest.php
@@ -65,7 +65,7 @@ class ConfigurationTest extends TestCase
             ->with('antimattr_migration_versions_test')
             ->willReturn($collection);
 
-        $cursor = $this->createMock('MongoDB\Cursor');
+        $cursor = $this->createMock('MongoDB\Driver\Cursor');
 
         $in = ['v' => ['$in' => ['20140822185742', '20140822185743', '20140822185744']]];
 
@@ -160,7 +160,7 @@ class ConfigurationTest extends TestCase
             ->with('antimattr_migration_versions_test')
             ->willReturn($collection);
 
-        $cursor = $this->createMock('MongoDB\Cursor');
+        $cursor = $this->createMock('MongoDB\Driver\Cursor');
 
         $collection->expects($this->once())
             ->method('find')
@@ -291,7 +291,7 @@ class ConfigurationTest extends TestCase
             ->with('antimattr_migration_versions_test')
             ->willReturn($collection);
 
-        $cursor = $this->createMock('MongoDB\Cursor');
+        $cursor = $this->createMock('MongoDB\Driver\Cursor');
 
         $collection->expects($this->once())
             ->method('find')
@@ -321,7 +321,7 @@ class ConfigurationTest extends TestCase
             ->with('antimattr_migration_versions_test')
             ->willReturn($collection);
 
-        $cursor = $this->createMock('MongoDB\Cursor');
+        $cursor = $this->createMock('MongoDB\Driver\Cursor');
 
         $collection->expects($this->once())
             ->method('find')

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationTest.php
@@ -12,7 +12,7 @@ class ConfigurationTest extends TestCase
 
     protected function setUp()
     {
-        $this->connection = $this->createMock('Doctrine\MongoDB\Connection');
+        $this->connection = $this->createMock('MongoDB\Client');
         $this->configuration = new Configuration($this->connection);
     }
 
@@ -28,8 +28,8 @@ class ConfigurationTest extends TestCase
         $this->configuration->setMigrationsDatabaseName('test_antimattr_migrations');
         $this->configuration->setMigrationsCollectionName('antimattr_migration_versions_test');
 
-        $expectedCollection = $this->createMock('Doctrine\MongoDB\Collection');
-        $database = $this->createMock('Doctrine\MongoDB\Database');
+        $expectedCollection = $this->createMock('MongoDB\Collection');
+        $database = $this->createMock('MongoDB\Database');
 
         $this->connection->expects($this->once())
             ->method('selectDatabase')
@@ -52,8 +52,8 @@ class ConfigurationTest extends TestCase
         $directory = dirname(__DIR__) . '/Resources/Migrations/';
         $this->configuration->registerMigrationsFromDirectory($directory);
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
-        $database = $this->createMock('Doctrine\MongoDB\Database');
+        $collection = $this->createMock('MongoDB\Collection');
+        $database = $this->createMock('MongoDB\Database');
 
         $this->connection->expects($this->once())
             ->method('selectDatabase')
@@ -65,7 +65,7 @@ class ConfigurationTest extends TestCase
             ->with('antimattr_migration_versions_test')
             ->willReturn($collection);
 
-        $cursor = $this->createMock('Doctrine\MongoDB\Cursor');
+        $cursor = $this->createMock('MongoDB\Cursor');
 
         $in = ['v' => ['$in' => ['20140822185742', '20140822185743', '20140822185744']]];
 
@@ -97,7 +97,7 @@ class ConfigurationTest extends TestCase
     {
         $this->configuration->setMigrationsDatabaseName('test_antimattr_migrations');
 
-        $expectedDatabase = $this->createMock('Doctrine\MongoDB\Database');
+        $expectedDatabase = $this->createMock('MongoDB\Database');
 
         $this->connection->expects($this->once())
             ->method('selectDatabase')
@@ -112,8 +112,8 @@ class ConfigurationTest extends TestCase
     {
         $this->prepareValidConfiguration();
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
-        $database = $this->createMock('Doctrine\MongoDB\Database');
+        $collection = $this->createMock('MongoDB\Collection');
+        $database = $this->createMock('MongoDB\Database');
 
         $this->connection->expects($this->once())
             ->method('selectDatabase')
@@ -147,8 +147,8 @@ class ConfigurationTest extends TestCase
     {
         $this->prepareValidConfiguration();
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
-        $database = $this->createMock('Doctrine\MongoDB\Database');
+        $collection = $this->createMock('MongoDB\Collection');
+        $database = $this->createMock('MongoDB\Database');
 
         $this->connection->expects($this->once())
             ->method('selectDatabase')
@@ -160,7 +160,7 @@ class ConfigurationTest extends TestCase
             ->with('antimattr_migration_versions_test')
             ->willReturn($collection);
 
-        $cursor = $this->createMock('Doctrine\MongoDB\Cursor');
+        $cursor = $this->createMock('MongoDB\Cursor');
 
         $collection->expects($this->once())
             ->method('find')
@@ -205,8 +205,8 @@ class ConfigurationTest extends TestCase
 
         $this->prepareValidConfiguration();
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
-        $database = $this->createMock('Doctrine\MongoDB\Database');
+        $collection = $this->createMock('MongoDB\Collection');
+        $database = $this->createMock('MongoDB\Database');
 
         $this->connection->expects($this->once())
             ->method('selectDatabase')
@@ -278,8 +278,8 @@ class ConfigurationTest extends TestCase
     {
         $this->prepareValidConfiguration();
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
-        $database = $this->createMock('Doctrine\MongoDB\Database');
+        $collection = $this->createMock('MongoDB\Collection');
+        $database = $this->createMock('MongoDB\Database');
 
         $this->connection->expects($this->once())
             ->method('selectDatabase')
@@ -291,7 +291,7 @@ class ConfigurationTest extends TestCase
             ->with('antimattr_migration_versions_test')
             ->willReturn($collection);
 
-        $cursor = $this->createMock('Doctrine\MongoDB\Cursor');
+        $cursor = $this->createMock('MongoDB\Cursor');
 
         $collection->expects($this->once())
             ->method('find')
@@ -308,8 +308,8 @@ class ConfigurationTest extends TestCase
     {
         $this->prepareValidConfiguration();
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
-        $database = $this->createMock('Doctrine\MongoDB\Database');
+        $collection = $this->createMock('MongoDB\Collection');
+        $database = $this->createMock('MongoDB\Database');
 
         $this->connection->expects($this->once())
             ->method('selectDatabase')
@@ -321,7 +321,7 @@ class ConfigurationTest extends TestCase
             ->with('antimattr_migration_versions_test')
             ->willReturn($collection);
 
-        $cursor = $this->createMock('Doctrine\MongoDB\Cursor');
+        $cursor = $this->createMock('MongoDB\Cursor');
 
         $collection->expects($this->once())
             ->method('find')

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/ConfigurationTest.php
@@ -65,28 +65,19 @@ class ConfigurationTest extends TestCase
             ->with('antimattr_migration_versions_test')
             ->willReturn($collection);
 
-        $cursor = $this->createMock('MongoDB\Driver\Cursor');
+        $cursor = $this->createMock('AntiMattr\Tests\MongoDB\Migrations\Configuration\CursorStub');
 
         $in = ['v' => ['$in' => ['20140822185742', '20140822185743', '20140822185744']]];
+        $options =  ['sort' => ['v' => -1], 'limit' => 1];
 
         $collection->expects($this->once())
             ->method('find')
-            ->with($in)
+            ->with($in, $options)
             ->willReturn($cursor);
 
         $cursor->expects($this->once())
-            ->method('sort')
-            ->with(['v' => -1])
-            ->willReturn($cursor);
-
-        $cursor->expects($this->once())
-            ->method('limit')
-            ->with(1)
-            ->willReturn($cursor);
-
-        $cursor->expects($this->once())
-            ->method('getNext')
-            ->willReturn(['v' => '20140822185743']);
+            ->method('toArray')
+            ->willReturn([['v' => '20140822185743']]);
 
         $version = $this->configuration->getCurrentVersion();
 
@@ -160,14 +151,8 @@ class ConfigurationTest extends TestCase
             ->with('antimattr_migration_versions_test')
             ->willReturn($collection);
 
-        $cursor = $this->createMock('MongoDB\Driver\Cursor');
-
         $collection->expects($this->once())
-            ->method('find')
-            ->willReturn($cursor);
-
-        $cursor->expects($this->once())
-            ->method('count')
+            ->method('countDocuments')
             ->willReturn(2);
 
         $this->assertEquals(2, $this->configuration->getNumberOfExecutedMigrations());
@@ -291,15 +276,15 @@ class ConfigurationTest extends TestCase
             ->with('antimattr_migration_versions_test')
             ->willReturn($collection);
 
-        $cursor = $this->createMock('MongoDB\Driver\Cursor');
+        $cursor = $this->createMock('AntiMattr\Tests\MongoDB\Migrations\Configuration\CursorStub');
 
         $collection->expects($this->once())
             ->method('find')
             ->willReturn($cursor);
 
-        $cursor->expects($this->exactly(2))
-            ->method('count')
-            ->willReturn(2);
+        $cursor->expects($this->once())
+            ->method('toArray')
+            ->willReturn([['v' => '20140822185743'],['v' => '20140822185743']]);
 
         $this->configuration->getMigratedTimestamp('1');
     }
@@ -321,19 +306,15 @@ class ConfigurationTest extends TestCase
             ->with('antimattr_migration_versions_test')
             ->willReturn($collection);
 
-        $cursor = $this->createMock('MongoDB\Driver\Cursor');
+        $cursor = $this->createMock('AntiMattr\Tests\MongoDB\Migrations\Configuration\CursorStub');
 
         $collection->expects($this->once())
             ->method('find')
             ->willReturn($cursor);
 
-        $cursor->expects($this->exactly(2))
-            ->method('count')
-            ->willReturn(1);
-
         $cursor->expects($this->once())
-            ->method('getNext')
-            ->willReturn(['t' => new \DateTime()]);
+            ->method('toArray')
+            ->willReturn([['v' => '20140822185743','t' => new \DateTime()]]);
 
         $this->assertTrue(is_numeric($this->configuration->getMigratedTimestamp('1')));
     }
@@ -345,5 +326,76 @@ class ConfigurationTest extends TestCase
         $this->configuration->setMigrationsDirectory($directory);
         $this->configuration->setMigrationsNamespace('Example\Migrations\TestAntiMattr\MongoDB');
         $this->configuration->setMigrationsCollectionName('antimattr_migration_versions_test');
+    }
+}
+
+/**
+ * A stub implementation for the MongoDB\Driver\Cursor class as that one is final
+ * The MongoDB\Driver\Cursor class encapsulates the results of a MongoDB command or query and may be returned by MongoDB\Driver\Manager::executeCommand() or MongoDB\Driver\Manager::executeQuery(), respectively.
+ * @link https://php.net/manual/en/class.mongodb-driver-cursor.php
+ */
+class CursorStub
+{
+    /**
+     * Create a new Cursor
+     * MongoDB\Driver\Cursor objects are returned as the result of an executed command or query and cannot be constructed directly.
+     * @link https://php.net/manual/en/mongodb-driver-cursor.construct.php
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Returns the MongoDB\Driver\CursorId associated with this cursor. A cursor ID cursor uniquely identifies the cursor on the server.
+     * @link https://php.net/manual/en/mongodb-driver-cursor.getid.php
+     * @return CursorId for this Cursor
+     * @throws InvalidArgumentException on argument parsing errors.
+     */
+    public function getId()
+    {
+    }
+
+    /**
+     * Returns the MongoDB\Driver\Server associated with this cursor. This is the server that executed the query or command.
+     * @link https://php.net/manual/en/mongodb-driver-cursor.getserver.php
+     * @return Server for this Cursor
+     * @throws InvalidArgumentException on argument parsing errors.
+     */
+    public function getServer()
+    {
+    }
+
+    /**
+     * Checks if a cursor is still alive
+     * @link https://php.net/manual/en/mongodb-driver-cursor.isdead.php
+     * @return boolean
+     * @throws InvalidArgumentException On argument parsing errors
+     */
+    public function isDead()
+    {
+    }
+
+    /**
+     * Sets a type map to use for BSON unserialization
+     *
+     * @link https://php.net/manual/en/mongodb-driver-cursor.settypemap.php
+     *
+     * @param array $typemap
+     * @return void
+     * @throws InvalidArgumentException On argument parsing errors or if a class in the type map cannot
+     * be instantiated or does not implement MongoDB\BSON\Unserializable
+     */
+    public function setTypeMap(array $typemap)
+    {
+    }
+
+    /**
+     * Returns an array of all result documents for this cursor
+     * @link https://php.net/manual/en/mongodb-driver-cursor.toarray.php
+     * @return array
+     * @throws InvalidArgumentException On argument parsing errors
+     */
+    public function toArray()
+    {
     }
 }

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Resources/Migrations/Version20140822185742.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Resources/Migrations/Version20140822185742.php
@@ -3,7 +3,7 @@
 namespace Example\Migrations\TestAntiMattr\MongoDB;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use \MongoDB\Database;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Resources/Migrations/Version20140822185743.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Resources/Migrations/Version20140822185743.php
@@ -3,7 +3,7 @@
 namespace Example\Migrations\TestAntiMattr\MongoDB;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use \MongoDB\Database;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Resources/Migrations/Version20140822185744.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Resources/Migrations/Version20140822185744.php
@@ -3,7 +3,7 @@
 namespace Example\Migrations\TestAntiMattr\MongoDB;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
-use Doctrine\MongoDB\Database;
+use \MongoDB\Database;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
@@ -438,12 +438,19 @@ class StatusCommandTest extends TestCase
             ->with("\n <info>==</info> Available Migration Versions\n")
         ;
 
-        $this->output->expects($this->at(40))
+        // Symfony 4.2 has different output
+        $consoleVersion = $this->getSymfonyConsoleVersion();
+        $index = 39;
+        if(version_compare($consoleVersion, '4.2.0', 'ge')) {
+            $index = 40;
+        }
+
+        $this->output->expects($this->at($index))
             ->method('writeln')
             ->with("\n <info>==</info> Previously Executed Unavailable Migration Versions\n")
         ;
 
-        $this->output->expects($this->at(41))
+        $this->output->expects($this->at(++$index))
             ->method('writeln')
             ->with(
                 sprintf(
@@ -459,6 +466,19 @@ class StatusCommandTest extends TestCase
             $input,
             $this->output
         );
+    }
+
+    /**
+     * @return mixed
+     */
+    private function getSymfonyConsoleVersion()
+    {
+        $versionData = [];
+        exec('composer show | grep symfony/console', $versionData);
+        $versionPart = explode('v', $versionData[0]);
+        $versionPart2 = explode(' ', $versionPart[1]);
+        $consoleVersion = $versionPart2[0];
+        return $consoleVersion;
     }
 }
 

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/StatusCommandTest.php
@@ -438,12 +438,12 @@ class StatusCommandTest extends TestCase
             ->with("\n <info>==</info> Available Migration Versions\n")
         ;
 
-        $this->output->expects($this->at(39))
+        $this->output->expects($this->at(40))
             ->method('writeln')
             ->with("\n <info>==</info> Previously Executed Unavailable Migration Versions\n")
         ;
 
-        $this->output->expects($this->at(40))
+        $this->output->expects($this->at(41))
             ->method('writeln')
             ->with(
                 sprintf(

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
@@ -63,7 +63,7 @@ class VersionTest extends TestCase
             ->with($collection);
 
         $collection->expects($this->once())
-            ->method('getName')
+            ->method('getCollectionName')
             ->will($this->returnValue('test_name'));
 
         $expectedException = new \RuntimeException();
@@ -86,7 +86,7 @@ class VersionTest extends TestCase
             ->with($collection);
 
         $collection->expects($this->once())
-            ->method('getName')
+            ->method('getCollectionName')
             ->will($this->returnValue('test_name'));
 
         $this->statistics->expects($this->once())
@@ -117,7 +117,7 @@ class VersionTest extends TestCase
         ];
 
         $collection->expects($this->once())
-            ->method('insert')
+            ->method('insertOne')
             ->with($insert);
 
         $this->version->markMigrated();
@@ -146,7 +146,7 @@ class VersionTest extends TestCase
         ];
 
         $collection->expects($this->once())
-            ->method('update')
+            ->method('updateOne')
             ->with($query, $update);
 
         $replay = true;
@@ -171,7 +171,7 @@ class VersionTest extends TestCase
         ];
 
         $collection->expects($this->once())
-            ->method('remove')
+            ->method('deleteOne')
             ->with($remove);
 
         $this->version->markNotMigrated();
@@ -209,7 +209,7 @@ class VersionTest extends TestCase
             ->will($this->returnValue($collection));
 
         $collection->expects($this->exactly(2))
-            ->method('getName')
+            ->method('getCollectionName')
             ->will($this->returnValue('test_name'));
 
         $this->statistics->expects($this->once())

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
@@ -5,7 +5,7 @@ namespace AntiMattr\Tests\MongoDB\Migrations;
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
 use AntiMattr\MongoDB\Migrations\Version;
 use PHPUnit\Framework\TestCase;
-use Doctrine\MongoDB\Database;
+use \MongoDB\Database;
 use MongoDB\BSON\UTCDateTime;
 
 class VersionTest extends TestCase
@@ -24,8 +24,8 @@ class VersionTest extends TestCase
     {
         $this->className = 'AntiMattr\Tests\MongoDB\Migrations\Version20140908000000';
         $this->configuration = $this->createMock('AntiMattr\MongoDB\Migrations\Configuration\Configuration');
-        $this->connection = $this->createMock('Doctrine\MongoDB\Connection');
-        $this->db = $this->createMock('Doctrine\MongoDB\Database');
+        $this->connection = $this->createMock('\MongoDB\Client');
+        $this->db = $this->createMock('\MongoDB\Database');
         $this->migration = $this->createMock('AntiMattr\Tests\MongoDB\Migrations\Version20140908000000');
         $this->outputWriter = $this->createMock('AntiMattr\MongoDB\Migrations\OutputWriter');
         $this->statistics = $this->createMock('AntiMattr\MongoDB\Migrations\Collection\Statistics');
@@ -57,7 +57,7 @@ class VersionTest extends TestCase
 
     public function testAnalyzeThrowsException()
     {
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('\MongoDB\Collection');
         $this->statistics->expects($this->once())
             ->method('setCollection')
             ->with($collection);
@@ -80,7 +80,7 @@ class VersionTest extends TestCase
 
     public function testAnalyze()
     {
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('\MongoDB\Collection');
         $this->statistics->expects($this->once())
             ->method('setCollection')
             ->with($collection);
@@ -103,7 +103,7 @@ class VersionTest extends TestCase
         $timestamp = new UTCDateTime();
         $this->version->setTimestamp($timestamp);
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('\MongoDB\Collection');
         $this->configuration->expects($this->once())
             ->method('createMigrationCollection');
 
@@ -128,7 +128,7 @@ class VersionTest extends TestCase
         $timestamp = new UTCDateTime();
         $this->version->setTimestamp($timestamp);
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('\MongoDB\Collection');
         $this->configuration->expects($this->once())
             ->method('createMigrationCollection');
 
@@ -158,7 +158,7 @@ class VersionTest extends TestCase
         $timestamp = new UTCDateTime();
         $this->version->setTimestamp($timestamp);
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('\MongoDB\Collection');
         $this->configuration->expects($this->once())
             ->method('createMigrationCollection');
 
@@ -179,7 +179,7 @@ class VersionTest extends TestCase
 
     public function testUpdateStatisticsAfterThrowsException()
     {
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('\MongoDB\Collection');
         $this->statistics->expects($this->once())
             ->method('setCollection')
             ->with($collection);
@@ -199,7 +199,7 @@ class VersionTest extends TestCase
 
     public function testUpdateStatisticsAfter()
     {
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('\MongoDB\Collection');
         $this->statistics->expects($this->once())
             ->method('setCollection')
             ->with($collection);
@@ -262,7 +262,7 @@ class VersionTest extends TestCase
             ->method($direction)
             ->will($this->throwException($expectedException));
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('\MongoDB\Collection');
         $this->configuration->expects($this->once())
             ->method('createMigrationCollection');
 
@@ -287,7 +287,7 @@ class VersionTest extends TestCase
         $this->migration->expects($this->once())
             ->method('post' . $direction);
 
-        $collection = $this->createMock('Doctrine\MongoDB\Collection');
+        $collection = $this->createMock('\MongoDB\Collection');
         $this->configuration->expects($this->once())
             ->method('createMigrationCollection');
 

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
@@ -12,7 +12,6 @@ class VersionTest extends TestCase
 {
     private $className;
     private $configuration;
-    private $connections;
     private $db;
     private $migration;
     private $version;
@@ -24,7 +23,6 @@ class VersionTest extends TestCase
     {
         $this->className = 'AntiMattr\Tests\MongoDB\Migrations\Version20140908000000';
         $this->configuration = $this->createMock('AntiMattr\MongoDB\Migrations\Configuration\Configuration');
-        $this->connection = $this->createMock('\MongoDB\Client');
         $this->db = $this->createMock('\MongoDB\Database');
         $this->migration = $this->createMock('AntiMattr\Tests\MongoDB\Migrations\Version20140908000000');
         $this->outputWriter = $this->createMock('AntiMattr\MongoDB\Migrations\OutputWriter');
@@ -34,9 +32,6 @@ class VersionTest extends TestCase
         $this->configuration->expects($this->once())
             ->method('getOutputWriter')
             ->will($this->returnValue($this->outputWriter));
-        $this->configuration->expects($this->once())
-            ->method('getConnection')
-            ->will($this->returnValue($this->connection));
         $this->configuration->expects($this->once())
             ->method('getDatabase')
             ->will($this->returnValue($this->db));


### PR DESCRIPTION
To prepare for doctrine mongo odm 2.0 which no longer has/supports
doctrine/mongodb (https://github.com/doctrine/mongodb-odm/blob/master/UPGRADE-2.0.md)

I guess this should warrant a new Major.

Let me know what other changes are needed? Current pull request changed just enough to make my own migrations run again when upgraded to odm 2.0 beta 1

Tests i need some help with