### PR TITLE
Packagist will not update until composer.json is all lowercase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0",
         "friendsofphp/php-cs-fixer": "^2.0",
-        "mikey179/vfsStream": "1.*"
+        "mikey179/vfsstream": "1.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
To fix this error in packagist:

```Importing branch master (dev-master)
Skipped branch master, Invalid package information: 
Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.
```